### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,6 @@
 members = [
     "programs/*"
 ]
+
+[profile.release]
+overflow-checks = true


### PR DESCRIPTION
otherwise, currently it shows an error:

$ anchor build

```
Error: `overflow-checks` is not enabled. To enable, add:

[profile.release]
overflow-checks = true

in workspace root Cargo.toml
```